### PR TITLE
set a timeout on proxy handlers HTTP calls

### DIFF
--- a/utils/proxy_handlers.py
+++ b/utils/proxy_handlers.py
@@ -25,7 +25,7 @@ class ProxyCheckers:
             response = get(target_url, proxies=proxies, timeout=self._time_out)
             if response.ok:
                 ip_api_url = f'http://ip-api.com/json/{proxy_host}'
-                ip_info = get(ip_api_url).json()
+                ip_info = get(ip_api_url, timeout=10.0).json()
                 country = ip_info.get('country')
 
                 return {

--- a/utils/response_handlers.py
+++ b/utils/response_handlers.py
@@ -13,7 +13,7 @@ class ResponseHandlers:
     def get_response(self, url) -> any([None, Response]):
         headers = self._generate_headers()
         try:
-            response = get(url=url, headers=headers)
+            response = get(url=url, headers=headers, timeout=10.0)
             return response
         except Exception as e:
             print('[-] Unable to fetch response: ', e)
@@ -22,7 +22,7 @@ class ResponseHandlers:
     def get_session_response(self, url) -> any([None, Response]):
         headers = self._generate_headers()
         try:
-            response = self._session.get(url=url, headers=headers)
+            response = self._session.get(url=url, headers=headers, timeout=10.0)
             return response
         except Exception as e:
             print('[-] Unable to fetch response: ', e)
@@ -31,7 +31,7 @@ class ResponseHandlers:
     def get_cloud_bypass_response(self, url) -> any([None, Response]):
         headers = self._generate_headers()
         try:
-            response = self._cloud_session.get(url=url, headers=headers)
+            response = self._cloud_session.get(url=url, headers=headers, timeout=10.0)
             return response
         except Exception as e:
             print('[-] Unable to fetch response: ', e)


### PR DESCRIPTION
I ran into this while reading through the code path around utils/proxy_handlers.py. Set a timeout on proxy handlers HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.