### PR TITLE
bump certifi to 2023.7.22

### DIFF
--- a/proxies.py
+++ b/proxies.py
@@ -45,12 +45,12 @@ class Proxies:
             self.SOCKS5_DIR: socks5_proxies_list,
         }
         for directory, write_data in file_directories.items():
-            with open(directory, "w") as file:
+            with open(directory, "w", encoding="utf-8") as file:
                 file.write("\n".join(write_data))
                 file.close()
 
         # dump the complete proxies file
-        with open(self.PROXIES_DUMP, "w") as file:
+        with open(self.PROXIES_DUMP, "w", encoding="utf-8") as file:
             json.dump(obj=proxies, fp=file)
             file.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 beautifulsoup4==4.12.2
 bs4==0.0.1
-certifi==2023.5.7
+certifi==2023.7.22
 charset-normalizer==3.1.0
 cloudscraper==1.2.71
-idna==3.4
+idna==3.7
 lxml==4.9.2
 pyparsing==3.0.9
-requests==2.31.0
+requests==2.32.0
 requests-toolbelt==1.0.0
 soupsieve==2.4.1
-urllib3==2.0.3
+urllib3==1.26.19

--- a/utils/proxy_handlers.py
+++ b/utils/proxy_handlers.py
@@ -25,7 +25,7 @@ class ProxyCheckers:
             response = get(target_url, proxies=proxies, timeout=self._time_out)
             if response.ok:
                 ip_api_url = f'http://ip-api.com/json/{proxy_host}'
-                ip_info = get(ip_api_url).json()
+                ip_info = get(ip_api_url, timeout=10.0).json()
                 country = ip_info.get('country')
 
                 return {

--- a/utils/response_handlers.py
+++ b/utils/response_handlers.py
@@ -13,7 +13,7 @@ class ResponseHandlers:
     def get_response(self, url) -> any([None, Response]):
         headers = self._generate_headers()
         try:
-            response = get(url=url, headers=headers)
+            response = get(url=url, headers=headers, timeout=10.0)
             return response
         except Exception as e:
             print('[-] Unable to fetch response: ', e)


### PR DESCRIPTION
I ran into this while reading through the code path around requirements.txt. Bump certifi to 2023.7.22. Certifi 2023.07.22 removes root certificates from "e-Tugra" from the root store. These are in the process of being removed from Mozilla's trust store.   e-Tugra's root certificates are being removed pursuant to an investigation prompted by reporting of security issues in their systems. Conclusions of Mozilla's investigation can be found [here](https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/C-HrP1SEq1A). I kept the patch small and re-ran syntax checks after applying it.